### PR TITLE
Handle deletions on the source.

### DIFF
--- a/kinto_signer/tests/functional.py
+++ b/kinto_signer/tests/functional.py
@@ -104,7 +104,8 @@ class FunctionalTest(unittest2.TestCase):
         # Trigger a signature.
         self.source.update_collection(data={'status': 'to-sign'}, method="put")
 
-        # Wait just a bit before doing the deletion.
+        # Wait so the new last_modified timestamp will be greater than the
+        # one from the previous records.
         time.sleep(0.01)
         # Now delete one record on the source and trigger another signature.
         self.source.delete_record(source_records[0]['id'])
@@ -118,6 +119,7 @@ class FunctionalTest(unittest2.TestCase):
         assert signature is not None
 
         serialized_records = canonical_json(records)
+        # This raises when the signature is invalid.
         self.signer.verify(serialized_records, signature)
 
 

--- a/kinto_signer/tests/functional.py
+++ b/kinto_signer/tests/functional.py
@@ -1,4 +1,5 @@
 import os.path
+import time
 from six.moves.urllib.parse import urljoin
 
 import unittest2
@@ -87,6 +88,38 @@ class FunctionalTest(unittest2.TestCase):
         # the status of the source collection should be "signed".
         source_collection = self.source.get_collection()['data']
         assert source_collection['status'] == 'signed'
+
+    def test_records_deletion_and_signature(self):
+        self.source.create_bucket()
+        self.source.create_collection()
+
+        # Create some data on the source collection and send it.
+        with self.source.batch() as batch:
+            for n in range(0, 10):
+                batch.create_record(data={'newdata': n})
+
+        source_records = self.source.get_records()
+        assert len(source_records) == 10
+
+        # Trigger a signature.
+        self.source.update_collection(data={'status': 'to-sign'}, method="put")
+
+        # Wait just a bit before doing the deletion.
+        time.sleep(0.01)
+        # Now delete one record on the source and trigger another signature.
+        self.source.delete_record(source_records[0]['id'])
+        self.source.update_collection(data={'status': 'to-sign'}, method="put")
+
+        records = self.destination.get_records()
+        assert len(records) == 9
+
+        data = self.destination.get_collection()
+        signature = data['data']['signature']
+        assert signature is not None
+
+        serialized_records = canonical_json(records)
+        self.signer.verify(serialized_records, signature)
+
 
 if __name__ == '__main__':
     unittest2.main()


### PR DESCRIPTION
Deleted records are now replicated to the destination collection when a new
signature is generated.

Fixes #25.

r? @leplatrem @Natim 